### PR TITLE
Allow passing `autoFocus` down to the `Editor` component

### DIFF
--- a/src/client/components/MarkdownInput/MarkdownInput.react.js
+++ b/src/client/components/MarkdownInput/MarkdownInput.react.js
@@ -10,6 +10,7 @@ class MarkdownInput extends React.Component {
     extensions: Types.array,
     additionalButtons: Types.array,
     readOnly: Types.bool,
+    autoFocus: Types.bool,
     showFullScreenButton: Types.bool,
     locale: Types.string
   };
@@ -21,6 +22,7 @@ class MarkdownInput extends React.Component {
     extensions: [],
     additionalButtons: [],
     readOnly: false,
+    autoFocus: true,
     showFullScreenButton: false,
     locale: 'en'
   };
@@ -34,7 +36,7 @@ class MarkdownInput extends React.Component {
   };
 
   render() {
-    const { value, extensions, additionalButtons, readOnly, showFullScreenButton, locale } = this.props;
+    const { value, extensions, additionalButtons, readOnly, showFullScreenButton, locale, autoFocus } = this.props;
 
     return (
       <PlainMarkdownInput
@@ -46,6 +48,7 @@ class MarkdownInput extends React.Component {
         readOnly={readOnly}
         showFullScreenButton={showFullScreenButton}
         locale={locale}
+        autoFocus={autoFocus}
       />
     );
   }

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
@@ -462,7 +462,7 @@ class PlainMarkdownInput extends React.Component {
 
   render() {
     const { editorState, fullScreen } = this.state;
-    const { children, extensions, readOnly, locale } = this.props;
+    const { children, extensions, readOnly, locale, autoFocus } = this.props;
     const disabled = readOnly || hasMultiLineSelection(editorState);
 
     // Create buttons for toolbar
@@ -497,7 +497,7 @@ class PlainMarkdownInput extends React.Component {
             spellCheck={false}
             state={editorState}
             fullScreen={fullScreen}
-            autoFocus={true}
+            autoFocus={autoFocus}
             schema={schema}
             onChange={this.handleChange}
             onCopy={this.handleCopy}
@@ -532,6 +532,7 @@ PlainMarkdownInput.propTypes = {
   onChange: Types.func,
   onFullScreen: Types.func,
   readOnly: Types.bool,
+  autoFocus: Types.bool,
   showFullScreenButton: Types.bool,
   locale: Types.string
 };
@@ -543,6 +544,7 @@ PlainMarkdownInput.defaultProps = {
   onFullScreen: () => {},
   onChange: () => {},
   readOnly: false,
+  autoFocus: true,
   showFullScreenButton: false,
   locale: 'en'
 };


### PR DESCRIPTION
This allows setting `autoFocus` on the component which is passed to the `Editor`. This way the developer can decide if they want to auto focus or not..

````jsx
<MarkdownInput autoFocus={false} />
````
This fixes #126

Possibly the component should actually not auto focus and force the developer to decide if they want to auto focus? i.e. `defaultProps` with `autoFocus: false` instead of `true`. Though this would break the current interface/expectation.
