### PR TITLE
Braces support in autocomplete plugin

### DIFF
--- a/src/client/components/MarkdownInput/MarkdownInput.DOCUMENTATION.md
+++ b/src/client/components/MarkdownInput/MarkdownInput.DOCUMENTATION.md
@@ -128,8 +128,9 @@ function (optional) that is called on when the user presses the button, the func
         objectClassName: 'Term',
         specialCharacter: '$',
         color: '#f396c3',
-        termRegex: /^\$(\w*)$/,
+        termRegex: /^\$(\w*|\[\w*\]?)$/,
         searchItems(term) {
+          const termId = term.replace(/^\$(?:\[(\w*)\]|\[?(\w*))$/, '$1$2');
           const items = [
             {_objectLabel: 'a1'},
             {_objectLabel: 'a2'},
@@ -145,10 +146,12 @@ function (optional) that is called on when the user presses the button, the func
             {_objectLabel: 'ba256'},
             {_objectLabel: 'ba257'}
           ];
-          return Promise.resolve(items.filter(({_objectLabel}) => _objectLabel.startsWith(term.substring(1))));
+          return Promise.resolve(items.filter(({_objectLabel}) => _objectLabel.startsWith(termId)));
         },
-        markdownText(item) {
-          return '$' + item._objectLabel + ' ';
+        markdownText(item, term) {
+          return term[1] === '[' ?
+            '$[' + item._objectLabel + '] ' :
+            '$' + item._objectLabel + ' ';
         }
       }
     ]}

--- a/src/client/components/MarkdownInputModal/MarkdownInputModal.DOCUMENTATION.md
+++ b/src/client/components/MarkdownInputModal/MarkdownInputModal.DOCUMENTATION.md
@@ -126,8 +126,9 @@ function (optional) that is called on when the user presses the button, the func
         objectClassName: 'Term',
         specialCharacter: '$',
         color: '#f396c3',
-        termRegex: /^\$(\w*)$/,
+        termRegex: /^\$(\w*|\[\w*\]?)$/,
         searchItems(term) {
+          const termId = term.replace(/^\$(?:\[(\w*)\]|\[?(\w*))$/, '$1$2');
           const items = [
             {_objectLabel: 'a1'},
             {_objectLabel: 'a2'},
@@ -143,10 +144,12 @@ function (optional) that is called on when the user presses the button, the func
             {_objectLabel: 'ba256'},
             {_objectLabel: 'ba257'}
           ];
-          return Promise.resolve(items.filter(({_objectLabel}) => _objectLabel.startsWith(term.substring(1))));
+          return Promise.resolve(items.filter(({_objectLabel}) => _objectLabel.startsWith(termId)));
         },
-        markdownText(item) {
-          return '$' + item._objectLabel + ' ';
+        markdownText(item, term) {
+          return term[1] === '[' ?
+            '$[' + item._objectLabel + '] ' :
+            '$' + item._objectLabel + ' ';
         }
       }
     ]}

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.spec.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.spec.js
@@ -863,27 +863,6 @@ describe('<PlainMarkdownInput />', () => {
     });
   });
 
-  describe('handleMouseDown()', () => {
-    it('handleMouseDown', () => {
-      let nodeText = 'text';
-      let component = (<PlainMarkdownInput
-        value={nodeText}
-        fullScreen={false}
-        readOnly={false}
-      />);
-
-      let wrapper = shallow(component);
-      let editorState = wrapper.state('editorState');
-      let change = editorState.change();
-      change.moveOffsetsTo(0, nodeText.length);
-      wrapper.setState({ editorState: change.state });
-      let wrapperInstance = wrapper.instance();
-      wrapperInstance.forceUpdate = sinon.spy();
-      wrapperInstance.handleMouseDown();
-      expect(wrapperInstance.forceUpdate.callCount).to.equal(1);
-    });
-  });
-
   describe('handleMouseUp ()', () => {
     it('handleMouseUp ', () => {
       let nodeText = 'text';

--- a/src/client/components/PlainMarkdownInput/buttons/ActionButton.js
+++ b/src/client/components/PlainMarkdownInput/buttons/ActionButton.js
@@ -12,19 +12,17 @@ const CLASSNAMES = {
   ol: 'list-ol',
 };
 
-const ActionButton = ({ onClick, disabled, locale, accent, active }) => {
-  return (
-    <button
-      className={classnames('btn btn-default', { active })}
-      disabled={disabled}
-      onClick={e => onClick(accent)}
-      type="button"
-      title={getMessage(locale, TITLES[accent] ? TITLES[accent] : accent)}
-    >
-      <i className={`fa fa-${CLASSNAMES[accent] ? CLASSNAMES[accent] : accent}`}/>
-    </button>
-  );
-};
+const ActionButton = ({ onClick, disabled, locale, accent, active }) => (
+  <button
+    className={classnames('btn btn-default', { active })}
+    disabled={disabled}
+    onClick={e => onClick(accent)}
+    type="button"
+    title={getMessage(locale, TITLES[accent] ? TITLES[accent] : accent)}
+  >
+    <i className={`fa fa-${CLASSNAMES[accent] ? CLASSNAMES[accent] : accent}`}/>
+  </button>
+)
 
 ActionButton.propTypes = {
   accent: Types.string,

--- a/src/client/components/PlainMarkdownInput/buttons/AdditionalButton.js
+++ b/src/client/components/PlainMarkdownInput/buttons/AdditionalButton.js
@@ -22,7 +22,7 @@ class AdditionalButton extends React.Component {
         disabled={disabled}
         onClick={e => (settings.handleButtonPress ? onClick(settings.handleButtonPress) : null)}
       >
-        {settings.iconElement ? settings.iconElement : ``}
+        {settings.iconElement ? settings.iconElement : ''}
         {(settings.iconElement ? ' ' : '') + (settings.label ? settings.label : '')}
       </button>
     );

--- a/src/client/components/PlainMarkdownInput/slate/schema.js
+++ b/src/client/components/PlainMarkdownInput/slate/schema.js
@@ -54,19 +54,15 @@ function markdownDecorator(text, block) {
   return text.characters;
 }
 
-let rendererComponent = props => {
-  let isLine = props.node.type === 'line';
-  let hasMarks = props.mark;
-
-  if (isLine) {
-    return (<div className="oc-md-hl-block">{props.children}</div>);
+let rendererComponent = ({ node, mark, children }) => {
+  if (node.type === 'line') {
+    return <div className="oc-md-hl-block">{children}</div>;
   }
 
-  if (hasMarks) {
-    const className = props.mark.type ? 'oc-md-hl-' + props.mark.type : '';
+  if (mark) {
     return (
-      <span className={className}>
-        {props.children}
+      <span className={mark.type ? `oc-md-hl-${mark.type}` : ''}>
+        {children}
       </span>
     );
   }

--- a/src/client/components/PlainMarkdownInput/slate/transforms.js
+++ b/src/client/components/PlainMarkdownInput/slate/transforms.js
@@ -512,8 +512,7 @@ function unwrapBlock(removedLength, state) {
  * @param {Object} state - editor state
  * @param {number} numLine
  */
-function hasListLine(accent, state, numLine = 0) {
-  let { texts } = state;
+function hasListLine(accent, { texts }, numLine = 0) {
   let text = texts.get(numLine).text;
   return MATCH_SINGLE_RULE[accent].test(text);
 }
@@ -537,14 +536,7 @@ function hasList(type, state) {
   }
 }
 
-export const getUlMarker = function(text) {
-  let res = ulRegExp.exec(text);
-  if (res) {
-    return res[0];
-  }
-
-  return false;
-};
+export const getUlMarker = text => (ulRegExp.exec(text) || [''])[0];
 
 export const getOlNum = function(text) {
   let res = olRegExp.exec(text);
@@ -821,13 +813,7 @@ const activities = {
   }
 };
 
-export const hasAccent = (state, accent) => {
-  if (activities.has[accent]) {
-    return activities.has[accent](state);
-  }
-
-  return false;
-};
+export const hasAccent = (state, accent) => !!activities.has[accent] && activities.has[accent](state);
 
 export const getAccents = state => {
   const accents = [];

--- a/src/client/components/translations.js
+++ b/src/client/components/translations.js
@@ -33,12 +33,5 @@ const translations = {
   }
 };
 
-export default function getMessage(locale, key) {
-  let translationExists = (translations[locale] && translations[locale][key]);
+export default (locale, key) => translations[locale] && translations[locale][key] || translations['en'][key];
 
-  if (!translationExists) {
-    return translations['en'][key];
-  }
-
-  return translations[locale][key];
-}


### PR DESCRIPTION
See issue #139 for details.

Second argument is added to `extensions.markdownText(item, term)` to
keep a user preference of braces for a term currenly worked on. The
argument is not needed if the braces are *always* added/ignored.