### PR TITLE
 #148 Fix - readOnly=true prop don't work for ordered and unordered list buttons

### DIFF
--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
@@ -456,7 +456,7 @@ class PlainMarkdownInput extends React.Component {
     let linkButton = this.getLinkButton({ disabled, locale });
     let headerButtons = this.getHeaderButtons({ disabled, locale });
     let listButtons = this.getAccentButtons({
-      editorValue: editorState, readOnly, locale, accents: ['ol', 'ul']
+      editorValue: editorState, disabled, locale, accents: ['ol', 'ul']
     });
     let additionalButtons = this.getAdditionalButtons(readOnly);
     let fullScreenButton = this.getFullScreenButton({ readOnly, locale, fullScreen });


### PR DESCRIPTION
Bugfixes
===

- readOnly=true prop don't work for ordered and unordered list buttons