### PR TITLE
#150 Add alternative solution to focus MarkdownInput within modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+[Release 2.3.3-beta.0](https://github.com/OpusCapita/react-markdown/releases/tag/v2.3.3-beta.0) Thu Sep 06 2018 21:24:34 GMT+0300 (MSK)
+=======================================================
+
+-  [#150](https://github.com/OpusCapita/react-markdown/issues/150) Fix selected autocomplete item highlighting (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-06 21:07:20 +0300)
+- Update unit tests (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-06 16:18:05 +0300)
+- Fix lint (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-05 21:23:18 +0300)
+- Refactor "autocomplete plugin" (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-05 21:19:28 +0300)
+- Refactor "autocomplete plugin" (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-05 20:48:54 +0300)
+-  [#150](https://github.com/OpusCapita/react-markdown/issues/150) Add alternative solution to focus MarkdownInput within modal (Kirill Volkovich kirill.volkovich@opuscapita.com, 2018-09-05 18:17:19 +0300)
+
 [Release 2.3.3](https://github.com/OpusCapita/react-markdown/releases/tag/v2.3.3) Tue Sep 04 2018 18:08:07 GMT+0300 (MSK)
 =======================================================
 

--- a/config/test/mocha-setup.js
+++ b/config/test/mocha-setup.js
@@ -20,3 +20,7 @@ chai.use(require('chai-enzyme')());
 global.document = jsdom('<!doctype html><html><body></body></html>');
 global.window = document.defaultView;
 global.navigator = global.window.navigator;
+
+global.window.getSelection = function() {
+  return { anchorNode: null };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opuscapita/react-markdown",
-  "version": "2.3.3-beta.0",
+  "version": "2.3.3-beta.1",
   "description": "React markdown editor component",
   "scripts": {
     "link-mode": "cross-env NODE_ENV=link webpack --config ./config/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opuscapita/react-markdown",
-  "version": "2.3.4",
+  "version": "2.3.3-beta.0",
   "description": "React markdown editor component",
   "scripts": {
     "link-mode": "cross-env NODE_ENV=link webpack --config ./config/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prismjs": "1.6.0",
     "prop-types": "15.5.10",
     "react-bootstrap": "0.31.2",
+    "react-click-outside": "3.0.1",
     "slate": "0.24.0",
     "slate-plain-serializer": "0.1.0",
     "slate-react": "0.1.0"

--- a/src/client/components/MarkdownInput/MarkdownInput.DOCUMENTATION.md
+++ b/src/client/components/MarkdownInput/MarkdownInput.DOCUMENTATION.md
@@ -2,7 +2,13 @@
 
 MarkdownInput
 
-### Props Reference
+### Methods reference
+
+| Name  | Description                                                                                                                                                             |
+| ----  | ----                                                                                                                                                                    |
+| focus | Force element focus. Can be useful in case of using within react-bootstrap Modal component with animation. Should be called as `onEntered` callback (on animation end). |
+
+### Props reference
 
 | Name               | Type            | Description                                                                                      |
 | ------------------ | :-------------- | ------------------------------------------------------------------------------------------------ |
@@ -12,7 +18,7 @@ MarkdownInput
 | locale             | string          | Locale                                                                                           |
 | extensions         | array           | See "Extension definition" section bellow.                                                       |
 | additionalButtons  | array           | See "Additional buttons definition" section bellow.                                              |
-| autoFocus          | bool            | Set focus automatically on mount (default: true)                                                 |
+| autoFocus          | bool            | Set focus automatically on mount (default: true). May not work within react-bootstrap modal. See `focus()` method.                                                 |
 | readOnly           | bool            | Disables toolbar and makes markdown text not editable.                                           |
 | hideToolbar        | bool            | Default: `false`. If `true`, input renders without a toolbar.                                           |
 

--- a/src/client/components/MarkdownInputModal/MarkdownInputModal.DOCUMENTATION.md
+++ b/src/client/components/MarkdownInputModal/MarkdownInputModal.DOCUMENTATION.md
@@ -54,7 +54,7 @@ function (optional) that is called on when the user presses the button, the func
 ```
 <div style={{ height: '70vh' }}>
   <MarkdownInputModal
-    onChange={_scope.handleValueChange}
+    ref={ref => (window.markdownInputModalRef = ref)}
     onFullScreen={_scope.handleFullScreen}
     value={_scope.state.markdownExample}
     readOnly={false}

--- a/src/client/components/MarkdownInputModal/MarkdownInputModal.SCOPE.react.js
+++ b/src/client/components/MarkdownInputModal/MarkdownInputModal.SCOPE.react.js
@@ -33,6 +33,10 @@ class MarkdownInputModalScope extends React.Component {
     this.setState({ fullScreen });
   };
 
+  handleModalAnimationEnd = () => {
+    window.markdownInputModalRef.focus();
+  }
+
   render() {
     const modalClasses = classNames({
       'markdown-input_fullscreen': this.state.fullScreen,
@@ -48,6 +52,8 @@ class MarkdownInputModalScope extends React.Component {
           className={modalClasses}
           show={this.state.show}
           onHide={this.handleHideModal}
+          animation={true}
+          onEntered={this.handleModalAnimationEnd}
         >
           <Modal.Header closeButton={true}>
             Modal Test

--- a/src/client/components/MarkdownInputModal/MarkdownInputModal.react.js
+++ b/src/client/components/MarkdownInputModal/MarkdownInputModal.react.js
@@ -38,6 +38,7 @@ class MarkdownInputModal extends React.Component {
 
     return (
       <PlainMarkdownInput
+        ref={ref => ref && (this.focus = ref.focus.bind(ref))}
         value={value}
         onChange={this.handleChangeValue}
         onFullScreen={this.handleFullScreen}

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.DOCUMENTATION.md
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.DOCUMENTATION.md
@@ -2,6 +2,12 @@
 
 PlainMarkdownInput
 
+### Methods reference
+
+| Name  | Description                                                                                                                                                             |
+| ----  | ----                                                                                                                                                                    |
+| focus | Force element focus. Can be useful in case of using within react-bootstrap Modal component with animation. Should be called as `onEntered` callback (on animation end). |
+
 ### Props Reference
 
 | Name                           | Type                    | Description                                                 |

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
@@ -290,13 +290,19 @@ class PlainMarkdownInput extends React.Component {
     this.slateContentRef = ref;
   }
 
+  focus = () => {
+    if (this.slateContentRef) {
+      this.slateContentRef.focus();
+    }
+  }
+
   handleScroll = () => {
     if (navigator.userAgent.match(/msie/i) || navigator.userAgent.match(/trident/i)) {
       // Works in the modal mode only in IE
       // In other browsers interception of focus does not work in the modal mode
       // (XXX: autocomplete widget loses focus after click on autocomplete scroll,
       // as a result pressing the Up Arrow and Down Arrow buttons cease to be processed)
-      this.slateContentRef.focus();
+      this.focus();
     } else {
       // This code in case of execution in IE as a ghost effect scrolls the content of the block to the top
       findDOMNode(this.slateContentRef).

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.spec.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.spec.js
@@ -29,12 +29,6 @@ describe('<PlainMarkdownInput />', () => {
 ###### header *italic*
 `;
 
-  before(() => {
-    window.getSelection = function() {
-      return { anchorNode: null };
-    };
-  });
-
   it('should have default props', () => {
     let component = <PlainMarkdownInput />;
     expect(component.props.extensions).to.deep.equal([]);

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/Autocomplete.less
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/Autocomplete.less
@@ -11,6 +11,11 @@
 .react-markdown--autocomplete-widget__item {
   flex: 1 0 auto;
   padding: 4px 12px;
+
+  &:hover {
+    cursor: default;
+    background-color: #f5f5f5;
+  }
 }
 
 .react-markdown--autocomplete-widget__item--active {

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Types from 'prop-types';
-import isEqual from 'lodash/isEqual';
 import clickOutside from 'react-click-outside';
 
 import AutocompleteWidget from './AutocompleteWidget';
@@ -236,7 +235,7 @@ class AutocompleteContainer extends React.Component {
 
   render() {
     const { show, selectedItem, items, ref, loading } = this.state;
-    const { children, state, locale } = this.props;
+    const { children, locale } = this.props;
 
     let selection = window.getSelection();
     if (selection.anchorNode) {

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.js
@@ -11,6 +11,7 @@ const escapeCode = 27;
 const arrowUpCode = 38;
 const arrowDownCode = 40;
 const enterCode = 13;
+const tabCode = 9;
 
 @clickOutside
 class AutocompleteContainer extends React.Component {
@@ -116,15 +117,25 @@ class AutocompleteContainer extends React.Component {
   handleKeyDown = (e) => {
     let { show, items, selectedItem } = this.state;
 
-    if (show && items) {
+    if (e.keyCode === tabCode) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.hideWidget();
+    }
+
+    if (show) {
       if (e.keyCode === escapeCode) {
         e.preventDefault();
         e.stopPropagation();
-        this.forceHide();
-      } else if (e.keyCode === enterCode) {
+        this.hideWidget();
+      }
+    }
+
+    if (show && items) {
+      if (e.keyCode === enterCode) {
         e.preventDefault();
         this.handleSelectItem(selectedItem, e);
-        this.forceHide();
+        this.hideWidget();
       } else if (e.keyCode === arrowUpCode || e.keyCode === arrowDownCode) {
         e.preventDefault();
         const length = items.length;
@@ -148,7 +159,6 @@ class AutocompleteContainer extends React.Component {
   };
 
   handleSelectItem = (index, event = null) => {
-    console.log('iiii', index);
     const { items } = this.state;
     const { state, options } = this.props;
     const { term } = this.getSearchToken(state);
@@ -204,11 +214,6 @@ class AutocompleteContainer extends React.Component {
   };
 
   hideWidget = () => {
-    const { show } = this.state;
-    this.toggleWidget(false);
-  };
-
-  forceHide = () => {
     this.toggleWidget(false);
   };
 

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.spec.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteContainer.spec.js
@@ -84,11 +84,11 @@ const extensions = [
 describe('<AutocompleteContainer />', () => {
   it('creation by default', () => {
     const nodeText = '';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
 
     let component = (<AutocompleteContainer
@@ -96,22 +96,22 @@ describe('<AutocompleteContainer />', () => {
       state={editorState}
     />);
     expect(component.props.options.extensions).to.deep.equal(extensions);
-    let wrapper = shallow(component);
-    let currState = wrapper.state();
-    expect(currState.show).to.equal(false);
-    expect(currState.selectedIndex).to.equal(0);
-    expect(currState.isMouseIndexSelected).to.equal(false);
-    expect(currState.items).to.deep.equal([]);
-    expect(currState.ref).to.equal(null);
+    let wrapper = mount(component);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
+
+    let state = autocompleteContainerElement.state;
+    expect(state.show).to.equal(false);
+    expect(state.selectedItem).to.equal(0);
+    expect(state.items).to.deep.equal([]);
   });
 
   it('componentWillReceiveProps(nextProps)', () => {
     const nodeText = '# Header1 ';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
     let editorChange = editorState.change();
     editorChange.moveOffsetsTo(nodeText.length - 1, nodeText.length - 1);
@@ -122,43 +122,45 @@ describe('<AutocompleteContainer />', () => {
       state={editorState}
     />);
     let wrapper = mount(component);
-    let wrapperInstance = wrapper.instance();
-    wrapperInstance.searchItems = sinon.spy();
-    wrapperInstance.componentWillReceiveProps({ state: editorState });
-    expect(wrapperInstance.searchItems.callCount).to.equal(1);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
+
+    autocompleteContainerElement.searchItems = sinon.spy();
+    autocompleteContainerElement.componentWillReceiveProps({ state: editorState });
+    expect(autocompleteContainerElement.searchItems.callCount).to.equal(1);
   });
 
   it('matchExtension(extensions, token)', () => {
     const nodeText = '';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
 
     let component = (<AutocompleteContainer
       options={{ extensions }}
       state={editorState}
     />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
+    let wrapper = mount(component);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
+
     let token = '#ba';
-    let extension = wrapperInstance.matchExtension(extensions, token);
+    let extension = autocompleteContainerElement.matchExtension(extensions, token);
     expect(extension).to.deep.equal(extensions[0]);
 
     token = 'ba';
-    extension = wrapperInstance.matchExtension(extensions, token);
+    extension = autocompleteContainerElement.matchExtension(extensions, token);
     expect(extension).to.deep.equal(undefined);
   });
 
   it('getSearchToken(state)', () => {
     const nodeText = '# Header1 ';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
     let editorChange = editorState.change();
     editorChange.moveOffsetsTo(nodeText.length - 1, nodeText.length - 1);
@@ -168,110 +170,91 @@ describe('<AutocompleteContainer />', () => {
       options={{ extensions }}
       state={editorState}
     />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
-    let { term, text, offset } = wrapperInstance.getSearchToken(editorState);
+    let wrapper = mount(component);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
+    let { term, text, offset } = autocompleteContainerElement.getSearchToken(editorState);
     expect(term).to.equal('Header1');
     expect(text).to.equal(nodeText);
     expect(offset).to.equal(2);
 
     editorChange.moveOffsetsTo(nodeText.length, nodeText.length);
     editorState = editorChange.state;
-    let res = wrapperInstance.getSearchToken(editorState);
+    let res = autocompleteContainerElement.getSearchToken(editorState);
     expect(res.term).to.equal('# Header1 ');
     expect(res.text).to.equal(nodeText);
     expect(res.offset).to.equal(-1);
   });
 
-  it('handleSelectedIndexChange(selectedIndex)', () => {
-    let inputComponent = (<PlainMarkdownInput
-      value=""
-      extensions={extensions}
-    />);
-    let inputWrapper = shallow(inputComponent);
-    let editorState = inputWrapper.state('editorState');
-
-    let component = (<AutocompleteContainer
-      options={{ extensions }}
-      state={editorState}
-    />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
-    wrapperInstance.handleSelectedIndexChange(3);
-    expect(wrapper.state('isMouseIndexSelected')).to.equal(true);
-    expect(wrapper.state('selectedIndex')).to.equal(3);
-  });
-
   it('handleKeyDown(e)', (done) => {
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value=""
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
 
     let component = (<AutocompleteContainer
       options={{ extensions }}
       state={editorState}
     />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
+    let wrapper = mount(component);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
 
     // is not shown
     event.keyCode = arrowDownCode;
-    wrapperInstance.handleKeyDown(event);
-    expect(wrapper.state('show')).to.equal(false);
-    expect(wrapper.state('selectedIndex')).to.equal(0);
+    autocompleteContainerElement.handleKeyDown(event);
+    expect(autocompleteContainerElement.state.show).to.equal(false);
+    expect(autocompleteContainerElement.state.selectedItem).to.equal(0);
 
     let extension = extensions[0];
     extension.searchItems('#ba').
     then((items) => {
-      wrapper.setState({ items, selectedIndex: 2, show: true });
+      autocompleteContainerElement.setState({ items, selectedItem: 2, show: true });
 
-      expect(wrapper.state('show')).to.equal(true);
-      expect(wrapper.state('selectedIndex')).to.equal(2);
+      expect(autocompleteContainerElement.state.show).to.equal(true);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(2);
 
       // escape
       event.keyCode = escapeCode;
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('show')).to.equal(false);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.show).to.equal(false);
 
       // enter
-      wrapper.setState({ show: true });
-      let backupHandleSelectItem = wrapperInstance.handleSelectItem;
-      wrapperInstance.handleSelectItem = sinon.spy();
+      autocompleteContainerElement.setState({ show: true });
+      let backupHandleSelectItem = autocompleteContainerElement.handleSelectItem;
+      autocompleteContainerElement.handleSelectItem = sinon.spy();
       event.keyCode = enterCode;
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapperInstance.handleSelectItem.getCall(0).args[0]).to.equal(2);
-      expect(wrapperInstance.handleSelectItem.callCount).to.equal(1);
-      wrapperInstance.handleSelectItem = backupHandleSelectItem;
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.handleSelectItem.getCall(0).args[0]).to.equal(2);
+      expect(autocompleteContainerElement.handleSelectItem.callCount).to.equal(1);
+      autocompleteContainerElement.handleSelectItem = backupHandleSelectItem;
 
       // arrowUpCode
-      wrapper.setState({ show: true });
+      autocompleteContainerElement.setState({ show: true });
       event.keyCode = arrowUpCode;
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(1);
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(0);
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(0);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(1);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(0);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(0);
 
       // arrowDownCode
-      wrapper.setState({ selectedIndex: 6 });
+      autocompleteContainerElement.setState({ selectedItem: 6 });
       event.keyCode = arrowDownCode;
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(7);
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(8);
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(8);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(7);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(8);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(8);
 
       // other
-      wrapper.setState({ selectedIndex: 6 });
+      autocompleteContainerElement.setState({ selectedItem: 6 });
       event.keyCode = 200;
-      wrapperInstance.handleKeyDown(event);
-      expect(wrapper.state('selectedIndex')).to.equal(6);
-      expect(wrapper.state('show')).to.equal(true);
+      autocompleteContainerElement.handleKeyDown(event);
+      expect(autocompleteContainerElement.state.selectedItem).to.equal(6);
+      expect(autocompleteContainerElement.state.show).to.equal(true);
 
       delete event.keyCode;
       done();
@@ -284,11 +267,11 @@ describe('<AutocompleteContainer />', () => {
 
   it.skip('handleSelectItem(index)', (done) => {
     const nodeText = '# bi2 #ba';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = shallow(markdownInputElement);
     inputWrapper.setState({ isFocused: true });
     let editorState = inputWrapper.state('editorState');
     let editorChange = editorState.change();
@@ -315,7 +298,7 @@ describe('<AutocompleteContainer />', () => {
     let extension = extensions[0];
     extension.searchItems('#ba').
     then((items) => {
-      wrapper.setState({ items, selectedIndex: 2, show: true });
+      wrapper.setState({ items, selectedItem: 2, show: true });
       expect(wrapper.state('show')).to.equal(true);
       wrapperInstance.handleSelectItem(2);
       expect(handlerChange.callCount).to.equal(1);
@@ -328,11 +311,11 @@ describe('<AutocompleteContainer />', () => {
 
   it('searchItems({ state, options })', (done) => {
     const nodeText = '# open #ba';
-    let inputComponent = (<PlainMarkdownInput
+    let markdownInputElement = (<PlainMarkdownInput
       value={nodeText}
       extensions={extensions}
     />);
-    let inputWrapper = shallow(inputComponent);
+    let inputWrapper = mount(markdownInputElement);
     let editorState = inputWrapper.state('editorState');
     let editorChange = editorState.change();
     editorChange.moveOffsetsTo(nodeText.length, nodeText.length);
@@ -342,22 +325,22 @@ describe('<AutocompleteContainer />', () => {
       options={{ extensions }}
       state={editorState}
     />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
+    let wrapper = mount(component);
+    let autocompleteContainerElement = wrapper.find(AutocompleteContainer).at(0).childAt(0).instance();
 
-    wrapper.setState({ show: true });
+    autocompleteContainerElement.setState({ show: true });
     editorChange.moveOffsetsTo('# open'.length, '# open'.length);
     editorState = editorChange.state;
-    wrapperInstance.searchItems({ state: editorState, options: { extensions } });
-    expect(wrapper.state('show')).to.equal(false);
-    expect(wrapper.state('items')).to.deep.equal([]);
+    autocompleteContainerElement.searchItems({ state: editorState, options: { extensions } });
+    expect(autocompleteContainerElement.state.show).to.equal(false);
+    expect(autocompleteContainerElement.state.items).to.deep.equal([]);
 
     editorChange.moveOffsetsTo(nodeText.length, nodeText.length);
     editorState = editorChange.state;
-    wrapperInstance.searchItems({ state: editorState, options: { extensions } });
+    autocompleteContainerElement.searchItems({ state: editorState, options: { extensions } });
 
     setTimeout(() => {
-      expect(wrapper.state('show')).to.equal(true);
+      expect(autocompleteContainerElement.state.show).to.equal(true);
       const pattern = [
         { _objectLabel: "ba2" },
         { _objectLabel: "ba21" },
@@ -369,27 +352,8 @@ describe('<AutocompleteContainer />', () => {
         { _objectLabel: "ba256" },
         { _objectLabel: "ba257" }
       ];
-      expect(wrapper.state('items')).to.deep.equal(pattern);
+      expect(autocompleteContainerElement.state.items).to.deep.equal(pattern);
       done();
     }, 100);
-  });
-
-  it('handleRef(ref)', () => {
-    let inputComponent = (<PlainMarkdownInput
-      value=""
-      extensions={extensions}
-    />);
-    let inputWrapper = shallow(inputComponent);
-    let editorState = inputWrapper.state('editorState');
-
-    let component = (<AutocompleteContainer
-      options={{ extensions }}
-      state={editorState}
-    />);
-    let wrapper = shallow(component);
-    let wrapperInstance = wrapper.instance();
-    let ref = { name: 'ref' };
-    wrapperInstance.handleRef(ref);
-    expect(wrapper.state('ref')).to.equal(ref);
   });
 });

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
@@ -156,15 +156,15 @@ export default class AutocompleteWidget extends React.Component {
     ) : null;
 
     let itemsElement = items.map((item, index) => {
-      const selected = selectedItem === index;
+      const isSelected = selectedItem === index;
       return (
         <div
           key={index}
           ref={ref => (this[`itemRef${index}`] = ref)}
           onMouseDown={_ => this.handleItemMouseDown(index)}
         >
-          <input type="radio" style={{ display: 'none' }} selected={selected} />
-          {itemRenderer({ item, selected })}
+          <input type="radio" style={{ display: 'none' }} selected={isSelected} />
+          {itemRenderer({ item, isSelected })}
         </div>
       );
     });

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
@@ -9,32 +9,25 @@ const maxHeight = 240;
 
 export default class AutocompleteWidget extends React.Component {
   static propTypes = {
-    isMouseIndexSelected: Types.bool,
-    onSelectedIndexChange: Types.func,
     items: Types.array,
+    loading: Types.bool,
     locale: Types.string,
-    onMouseDown: Types.func,
-    onMouseUp: Types.func,
-    onScroll: Types.func,
-    onSelectItem: Types.func,
-    selectedIndex: Types.number,
-    style: Types.object,
+    onChange: Types.func,
+    itemRenderer: Types.func,
     restrictorRef: Types.object,
-    renderItem: Types.func,
-    loading: Types.bool
+    selectedItem: Types.number,
+    style: Types.object
   }
 
   static defaultProps = {
-    isMouseIndexSelected: false,
-    onSelectedIndexChange: () => {},
     items: [],
+    loading: false,
     locale: 'en',
-    onMouseDown: () => {},
-    onMouseUp: () => {},
-    onScroll: () => {},
-    onSelectItem: () => {},
-    style: {},
-    restrictorRef: null
+    onChange: () => {},
+    itemRenderer: DefaultAutocompleteItem,
+    restrictorRef: null,
+    selectedItem: null,
+    style: {}
   };
 
   constructor(props) {
@@ -48,27 +41,11 @@ export default class AutocompleteWidget extends React.Component {
 
   componentDidMount = () => {
     this.adjustPosition();
-    this['items-ref'].addEventListener('scroll', this.props.onScroll, false);
   };
 
   componentWillReceiveProps = (nextProps) => {
     this.cancelAdjustPosition();
     this.adjustPosition();
-  };
-
-  componentWillUpdate = (nextProps) => {
-    let { isMouseIndexSelected } = this.props;
-    let itemsRef = this['items-ref'];
-    let itemRef = this[`item-ref-${nextProps.selectedIndex}`];
-
-    if (itemsRef && itemRef && !isMouseIndexSelected) { // calculating scrolling with keyboard up and down arrows
-      if ((this.props.selectedIndex < nextProps.selectedIndex) && (itemRef.offsetTop - itemsRef.scrollTop > 156)) {
-        itemsRef.scrollTop = (itemRef.offsetTop - 156);
-      }
-      if ((this.props.selectedIndex > nextProps.selectedIndex) && (itemRef.offsetTop - itemsRef.scrollTop < 26)) {
-        itemsRef.scrollTop = (itemRef.offsetTop - 26);
-      }
-    }
   };
 
   componentWillUnmount = () => {
@@ -81,15 +58,11 @@ export default class AutocompleteWidget extends React.Component {
     }
   };
 
-  handleSelectItem = index => {
-    this.props.onSelectItem(index);
-  };
-
-  setPosition = (selection) => {
+  setPosition = (selectedItem) => {
     let editorWidth = this.props.restrictorRef.offsetWidth;
-    let autocompleteWidth = this['items-ref'].offsetWidth;
-    let autocompleteHeight = this['items-ref'].offsetHeight;
-    let selectionRect = selection.getRangeAt(0).getBoundingClientRect(); // element with cursor
+    let autocompleteWidth = this['containerRef'].offsetWidth;
+    let autocompleteHeight = this['containerRef'].offsetHeight;
+    let selectionRect = selectedItem.getRangeAt(0).getBoundingClientRect(); // element with cursor
     let restrictorRect = this.props.restrictorRef.getBoundingClientRect();
     let lineHeight = selectionRect.bottom - selectionRect.top;
 
@@ -98,8 +71,8 @@ export default class AutocompleteWidget extends React.Component {
     left = left < 0 ? 0 : left;
 
     let top = selectionRect.top - restrictorRect.top + lineHeight + 4;
-    let offsetTop = selection.anchorNode.parentNode.offsetTop;
-    let slateEditor = getSlateEditor(selection);
+    let offsetTop = selectedItem.anchorNode.parentNode.offsetTop;
+    let slateEditor = getSlateEditor(selectedItem);
 
     slateEditor.style.overflow = 'hidden';
 
@@ -123,29 +96,16 @@ export default class AutocompleteWidget extends React.Component {
   };
 
   adjustPosition = () => {
-    let selection = window.getSelection();
+    let selectedItem = window.getSelection();
 
-    if (selection.anchorNode) {
-      this.setPosition(selection);
+    if (selectedItem.anchorNode) {
+      this.setPosition(selectedItem);
     }
   };
 
-  saveRef = ref => (this['items-ref'] = ref);
-
-  handleMouseDown = e => {
-    e.preventDefault(); // XXX Not work in IE11
-    e.stopPropagation(); // Isolate event target
-    this.props.onMouseDown('widget');
-  }
-
-  handleMouseUp = e => {
-    e.stopPropagation(); // Isolate event target
-    this.props.onMouseUp();
-  }
-
-  handleItemMouseDown = e => {
-    e.stopPropagation(); // Isolate event target
-    this.props.onMouseDown('item');
+  handleItemMouseDown = (index) => {
+    console.log('click');
+    this.props.onChange(index);
   }
 
   render() {
@@ -153,65 +113,68 @@ export default class AutocompleteWidget extends React.Component {
     const {
       items,
       locale,
-      selectedIndex,
-      onSelectedIndexChange,
-      onSelectItem,
-      renderItem: CustomItemComponent,
+      selectedItem,
+      onChange,
+      itemRenderer,
       loading
     } = this.props;
 
-    const ItemComponent = CustomItemComponent ? CustomItemComponent : DefaultAutocompleteItem;
-
-    const commonProps = {
-      className: "react-markdown--autocomplete-widget",
-      ref: this.saveRef,
-      style: {
-        left,
-        top,
-        transform,
-        maxHeight: `${maxHeight}px`,
-        ...this.props.style
-      }
-    }
-
     if (loading) {
       return (
-        <div {...commonProps}>
+        <div
+          ref={ref => (this.containerRef = ref)}
+          style={{
+            left,
+            top,
+            transform,
+            maxHeight: `${maxHeight}px`,
+            ...this.props.style
+          }}
+          className="react-markdown--autocomplete-widget"
+        >
           <div className="react-markdown--autocomplete-widget__item">
             <span>{getMessage(locale, 'searching')}</span>
             <i className="fa fa-spinner fa-spin pull-right" style={{ marginTop: '3px' }}></i>
           </div>
         </div>
-      )
+      );
     }
+
+    let notFoundElement = items.length === 0 && !loading ? (
+      <div className="react-markdown--autocomplete-widget__item">{getMessage(locale, 'noMatchesFound')}</div>
+    ) : null;
+
+    let itemsElement = items.map((item, index) => {
+      const selected = selectedItem === index;
+      return (
+        <div
+          key={index}
+          ref={ref => (this[`itemRef${index}`] = ref)}
+          onMouseDown={_ => this.handleItemMouseDown(index)}
+        >
+          <input type="radio" style={{ display: 'none' }} selected={selected} />
+          {itemRenderer({ item, selected })}
+        </div>
+      );
+    });
 
     if (items) {
       return (
         <div
-          {...commonProps}
-          onMouseDown={this.handleMouseDown}
-          onMouseUp={this.handleMouseUp}
-        >
-          {items.map((item, index) => {
-            return (
-              <div
-                key={index}
-                ref={ref => (this[`item-ref-${index}`] = ref)}
-                onClick={_ => onSelectItem(index)}
-                onMouseMove={_ => onSelectedIndexChange(index)}
-                onMouseDown={this.handleItemMouseDown}
-              >
-                <ItemComponent
-                  item={item}
-                  isSelected={selectedIndex === index}
-                />
-              </div>
-            );
-          })}
-
-          {items.length === 0 && !loading && (
-            <div className="react-markdown--autocomplete-widget__item">{getMessage(locale, 'noMatchesFound')}</div>
-          )}
+          ref={ref => (this.containerRef = ref)}
+          style={{
+            left,
+            top,
+            transform,
+            maxHeight: `${maxHeight}px`,
+            ...this.props.style
+          }}
+          className="react-markdown--autocomplete-widget"
+       >
+          <fieldset>
+            {itemsElement}
+          </fieldset>
+          {notFoundElement}
         </div>
       );
     }
@@ -219,4 +182,3 @@ export default class AutocompleteWidget extends React.Component {
     return null;
   }
 }
-

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
@@ -117,7 +117,6 @@ export default class AutocompleteWidget extends React.Component {
   };
 
   handleItemMouseDown = (index) => {
-    console.log('click');
     this.props.onChange(index);
   }
 

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
@@ -52,6 +52,19 @@ export default class AutocompleteWidget extends React.Component {
     this.cancelAdjustPosition();
   };
 
+  componentWillUpdate = (nextProps) => {
+    let containerRef = this.containerRef;
+    let itemRef = this[`itemRef${nextProps.selectedItem}`];
+    if (containerRef && itemRef) { // calculating scrolling with keyboard up and down arrows
+      if ((this.props.selectedItem < nextProps.selectedItem) && (itemRef.offsetTop - containerRef.scrollTop > 156)) {
+        containerRef.scrollTop = (itemRef.offsetTop - 156);
+      }
+      if ((this.props.selectedItem > nextProps.selectedItem) && (itemRef.offsetTop - containerRef.scrollTop < 26)) {
+        containerRef.scrollTop = (itemRef.offsetTop - 26);
+      }
+    }
+  };
+
   cancelAdjustPosition = () => {
     if (this._animationFrame) {
       window.cancelAnimationFrame(this._animationFrame); // XXX

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.js
@@ -48,10 +48,6 @@ export default class AutocompleteWidget extends React.Component {
     this.adjustPosition();
   };
 
-  componentWillUnmount = () => {
-    this.cancelAdjustPosition();
-  };
-
   componentWillUpdate = (nextProps) => {
     let containerRef = this.containerRef;
     let itemRef = this[`itemRef${nextProps.selectedItem}`];
@@ -63,6 +59,10 @@ export default class AutocompleteWidget extends React.Component {
         containerRef.scrollTop = (itemRef.offsetTop - 26);
       }
     }
+  };
+
+  componentWillUnmount = () => {
+    this.cancelAdjustPosition();
   };
 
   cancelAdjustPosition = () => {
@@ -127,7 +127,6 @@ export default class AutocompleteWidget extends React.Component {
       items,
       locale,
       selectedItem,
-      onChange,
       itemRenderer,
       loading
     } = this.props;
@@ -183,7 +182,7 @@ export default class AutocompleteWidget extends React.Component {
             ...this.props.style
           }}
           className="react-markdown--autocomplete-widget"
-       >
+        >
           <fieldset>
             {itemsElement}
           </fieldset>

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.spec.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/AutocompleteWidget.spec.js
@@ -72,31 +72,10 @@ window.cancelAnimationFrame = callback => {
 window.requestAnimationFrame = callback => callback;
 
 describe('<AutocompleteWidget />', () => {
-  it('componentDidMount()', () => {
-    const handler = sinon.spy();
-    const listener = sinon.spy();
-    let component = (
-      <AutocompleteWidget
-        selectedIndex={0}
-        onMouseDown={() => {}}
-        onScroll={handler}
-      />
-    );
-    let wrapper = mount(component);
-    let wrapperInstance = wrapper.instance();
-    wrapperInstance.adjustPosition = sinon.spy();
-    wrapperInstance['items-ref'] = { addEventListener: listener };
-    wrapperInstance.componentDidMount();
-    expect(listener.callCount).to.equal(1);
-    expect(listener.getCall(0).args[0]).to.equal('scroll');
-    expect(listener.getCall(0).args[1]).to.equal(handler);
-    expect(listener.getCall(0).args[2]).to.equal(false);
-  });
-
   it('componentWillReceiveProps(nextProps)', () => {
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
@@ -110,37 +89,37 @@ describe('<AutocompleteWidget />', () => {
   });
 
   it('componentWillUpdate(nextProps)', () => {
-    const selectedIndex = 2;
+    const selectedItem = 2;
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
     let wrapper = mount(component);
     let wrapperInstance = wrapper.instance();
-    wrapperInstance['items-ref'] = { scrollTop: 25 };
-    wrapperInstance['item-ref-2'] = { offsetTop: 50 };
-    wrapperInstance.componentWillUpdate({ selectedIndex });
-    expect(wrapperInstance['items-ref'].scrollTop).to.equal(25);
+    wrapperInstance.containerRef = { scrollTop: 25 };
+    wrapperInstance['itemRef2'] = { offsetTop: 50 };
+    wrapperInstance.componentWillUpdate({ selectedItem });
+    expect(wrapperInstance.containerRef.scrollTop).to.equal(25);
 
-    wrapper.setProps({ selectedIndex: 3 });
-    wrapperInstance['items-ref'] = { scrollTop: 25 };
-    wrapperInstance['item-ref-2'] = { offsetTop: 50 };
-    wrapperInstance.componentWillUpdate({ selectedIndex });
-    expect(wrapperInstance['items-ref'].scrollTop).to.equal(24);
+    wrapper.setProps({ selectedItem: 3 });
+    wrapperInstance.containerRef = { scrollTop: 25 };
+    wrapperInstance['itemRef2'] = { offsetTop: 50 };
+    wrapperInstance.componentWillUpdate({ selectedItem });
+    expect(wrapperInstance.containerRef.scrollTop).to.equal(24);
 
-    wrapper.setProps({ selectedIndex: 1 });
-    wrapperInstance['items-ref'] = { scrollTop: 25 };
-    wrapperInstance['item-ref-2'] = { offsetTop: 200 };
-    wrapperInstance.componentWillUpdate({ selectedIndex });
-    expect(wrapperInstance['items-ref'].scrollTop).to.equal(44);
+    wrapper.setProps({ selectedItem: 1 });
+    wrapperInstance.containerRef = { scrollTop: 25 };
+    wrapperInstance['itemRef2'] = { offsetTop: 200 };
+    wrapperInstance.componentWillUpdate({ selectedItem });
+    expect(wrapperInstance.containerRef.scrollTop).to.equal(44);
   });
 
   it('componentWillUnmount()', () => {
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
@@ -159,19 +138,19 @@ describe('<AutocompleteWidget />', () => {
         return {
           left: 255,
           top: 500
-        }
+        };
       }
     };
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
     let wrapper = mount(component);
     wrapper.setProps({ restrictorRef });
     let wrapperInstance = wrapper.instance();
-    wrapperInstance['items-ref'] = {
+    wrapperInstance.containerRef = {
       offsetHeight: 500,
       offsetWidth: 300
     };
@@ -206,7 +185,7 @@ describe('<AutocompleteWidget />', () => {
   it('adjustPosition()', () => {
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
@@ -220,7 +199,7 @@ describe('<AutocompleteWidget />', () => {
   it('cancelAdjustPosition()', () => {
     let component = (
       <AutocompleteWidget
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );
@@ -232,28 +211,11 @@ describe('<AutocompleteWidget />', () => {
     expect(wrapperInstance._animationFrame.callCount).to.equal(1);
   });
 
-  it('handleSelectItem(index)', () => {
-    let handler = sinon.spy();
-    let index = 2;
-    let component = (
-      <AutocompleteWidget
-        selectedIndex={0}
-        onMouseDown={() => {}}
-        onSelectItem={handler}
-      />
-    );
-    let wrapper = mount(component);
-    let wrapperInstance = wrapper.instance();
-    wrapperInstance.handleSelectItem(index);
-    expect(handler.callCount).to.equal(1);
-    expect(handler.getCall(0).args[0]).to.equal(index);
-  });
-
   it('render() with empty items', () => {
     let component = (
       <AutocompleteWidget
         items={null}
-        selectedIndex={0}
+        selectedItem={0}
         onMouseDown={() => {}}
       />
     );

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/DefaultAutocompleteItem.react.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/DefaultAutocompleteItem.react.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const maxItemLength = 15;
 
-export default function DefaultAutocompleteItem({ item, selected }) {
+export default function DefaultAutocompleteItem({ item, isSelected }) {
   const itemLabel = item._objectLabel;
   const itemLength = itemLabel.length;
 
@@ -11,7 +11,7 @@ export default function DefaultAutocompleteItem({ item, selected }) {
     <div
       className={`
         react-markdown--autocomplete-widget__item
-        ${selected ? 'react-markdown--autocomplete-widget__item--active' : ''}
+        ${isSelected ? 'react-markdown--autocomplete-widget__item--active' : ''}
       `}
       title={itemLength > maxItemLength ? itemLabel : ''}
     >
@@ -22,5 +22,5 @@ export default function DefaultAutocompleteItem({ item, selected }) {
 
 DefaultAutocompleteItem.propTypes = {
   item: PropTypes.object.isRequired,
-  selected: PropTypes.bool.isRequired
+  isSelected: PropTypes.bool.isRequired
 };

--- a/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/DefaultAutocompleteItem.react.js
+++ b/src/client/components/PlainMarkdownInput/plugins/slate-autocomplete-plugin/DefaultAutocompleteItem.react.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const maxItemLength = 15;
 
-export default function DefaultAutocompleteItem({ item, isSelected }) {
+export default function DefaultAutocompleteItem({ item, selected }) {
   const itemLabel = item._objectLabel;
   const itemLength = itemLabel.length;
 
@@ -11,16 +11,16 @@ export default function DefaultAutocompleteItem({ item, isSelected }) {
     <div
       className={`
         react-markdown--autocomplete-widget__item
-        ${isSelected ? 'react-markdown--autocomplete-widget__item--active' : ''}
+        ${selected ? 'react-markdown--autocomplete-widget__item--active' : ''}
       `}
       title={itemLength > maxItemLength ? itemLabel : ''}
     >
       {itemLength > maxItemLength ? `${itemLabel.substr(0, maxItemLength)}…` : itemLabel}
     </div>
-  )
+  );
 }
 
 DefaultAutocompleteItem.propTypes = {
   item: PropTypes.object.isRequired,
-  isSelected: PropTypes.bool.isRequired
-}
+  selected: PropTypes.bool.isRequired
+};


### PR DESCRIPTION
Enhancements
=====

- Add `focus` method for MarkdownInput component.
  It can be used in cases when `autoFocus` property doesn't work.
  For example where it used within react-bootstrap modal component.

Refactoring
=====

- Refactor autocomplete plugin rendering logic. Removed odd code. Item selection using up/down arrow keys replaced by browser-native capabilities (using fieldset + hidden checkboxes).
- Refactor autocomplete show/hide behavior.