### PR TITLE
Pass spellCheck property on to Slate Editor, default to false.

### DIFF
--- a/src/client/components/MarkdownInput/MarkdownInput.react.js
+++ b/src/client/components/MarkdownInput/MarkdownInput.react.js
@@ -13,6 +13,7 @@ class MarkdownInput extends React.Component {
     readOnly: Types.bool,
     autoFocus: Types.bool,
     showFullScreenButton: Types.bool,
+    spellCheck: Types.bool,
     locale: Types.string,
     hideToolbar: Types.bool
   };
@@ -27,6 +28,7 @@ class MarkdownInput extends React.Component {
     readOnly: false,
     autoFocus: true,
     showFullScreenButton: false,
+    spellCheck: false,
     locale: 'en',
     hideToolbar: false
   };

--- a/src/client/components/MarkdownInputModal/MarkdownInputModal.react.js
+++ b/src/client/components/MarkdownInputModal/MarkdownInputModal.react.js
@@ -11,6 +11,7 @@ class MarkdownInputModal extends React.Component {
     additionalButtons: Types.array,
     readOnly: Types.bool,
     showFullScreenButton: Types.bool,
+    spellCheck: Types.bool,
     locale: Types.string
   };
 
@@ -22,6 +23,7 @@ class MarkdownInputModal extends React.Component {
     additionalButtons: [],
     readOnly: false,
     showFullScreenButton: false,
+    spellCheck: false,
     locale: 'en'
   };
 
@@ -34,7 +36,7 @@ class MarkdownInputModal extends React.Component {
   };
 
   render() {
-    const { value, extensions, additionalButtons, readOnly, showFullScreenButton, locale } = this.props;
+    const { value, extensions, additionalButtons, readOnly, showFullScreenButton, spellCheck, locale } = this.props;
 
     return (
       <PlainMarkdownInput
@@ -46,6 +48,7 @@ class MarkdownInputModal extends React.Component {
         additionalButtons={additionalButtons}
         readOnly={readOnly}
         showFullScreenButton={showFullScreenButton}
+        spellCheck={spellCheck}
         locale={locale}
       />
     );

--- a/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
+++ b/src/client/components/PlainMarkdownInput/PlainMarkdownInput.react.js
@@ -80,6 +80,7 @@ class PlainMarkdownInput extends PureComponent {
     readOnly: Types.bool,
     autoFocus: Types.bool,
     showFullScreenButton: Types.bool,
+    spellCheck: Types.bool,
     locale: Types.string,
     hideToolbar: Types.bool
   }
@@ -94,7 +95,8 @@ class PlainMarkdownInput extends PureComponent {
     readOnly: false,
     autoFocus: true,
     showFullScreenButton: false,
-    locale: 'en'
+    spellCheck: false,
+    locale: 'en',
   }
 
   state = {
@@ -493,7 +495,7 @@ class PlainMarkdownInput extends PureComponent {
 
   render() {
     const { editorState, fullScreen } = this.state;
-    const { children, extensions, readOnly, locale, autoFocus, hideToolbar } = this.props;
+    const { children, extensions, readOnly, locale, autoFocus, hideToolbar, spellCheck } = this.props;
     const disabled = readOnly || hasMultiLineSelection(editorState);
 
     // Create buttons for toolbar
@@ -510,7 +512,7 @@ class PlainMarkdownInput extends PureComponent {
 
     const editor = (
       <Editor
-        spellCheck={false}
+        spellCheck={spellCheck}
         state={editorState}
         fullScreen={fullScreen}
         autoFocus={autoFocus}


### PR DESCRIPTION
Using `MarkdownInput` in my project, I would like to enable spellcheck on the editor.

This PR adds a prop for `spellCheck` which is passed down to the Slate `Editor` component.

The default value is `false`